### PR TITLE
Helped aggregation

### DIFF
--- a/contracts/BLS.sol
+++ b/contracts/BLS.sol
@@ -450,7 +450,7 @@ library BLS {
     // each signer submits two public keys(in G1&G2) corresponding to their secret key
 
     /// @notice verify if both public keys have the same secret
-    /// @dev not sufficient to check for rogue-key attacks, use verifyHelpedAggregated instead
+    /// @dev not sufficient to check for rogue-key attacks, use verifyHelpedAggregationPublicKeysRec instead
     /// @param pubkeyG1 public key in G1 
     /// @param pubkeyG2 public key in G2
     function verifyHelpedAggregationPublicKeys(
@@ -473,7 +473,7 @@ library BLS {
     }
 
     /// @notice verifies if a list of pubkeysG2 is equivalent to aggPubKeyG1 that is aggregated off chain
-    /// @dev not sufficient to check for rogue-key attacks, use verifyHelpedAggregated instead
+    /// @dev not sufficient to check for rogue-key attacks, use verifyHelpedAggregationPublicKeysRec instead
     /// @param aggPubkeyG1 public key in G1(aggregated off chain) 
     /// @param pubkeysG2 list of public keys in G2 
     function verifyHelpedAggregationPublicKeysMultiple(

--- a/contracts/TestBLS.sol
+++ b/contracts/TestBLS.sol
@@ -149,4 +149,26 @@ contract TestBLS {
     function isValidCompressedSignature(uint256 compressed) external view returns (bool) {
         return BLS.isValidCompressedSignature(compressed);
     }
+
+    function verifyHelpedAggregationPublicKeys(
+        uint256[2] memory pubKeyG1,
+        uint256[4] memory pubkey
+    ) external view returns (bool) {
+        return BLS.verifyHelpedAggregationPublicKeys(pubKeyG1,pubkey);
+    }
+
+    function verifyHelpedAggregationPublicKeysMultiple(
+        uint256[2] memory pubKeyG1,
+        uint256[4][] memory pubkeys
+    ) external view returns (bool) {
+        return BLS.verifyHelpedAggregationPublicKeysMultiple(pubKeyG1,pubkeys);
+    }
+
+    function verifyHelpedAggregationPublicKeysRec(
+        uint256[2] memory aggregated_p1, uint256[4] memory aggregated_g2, 
+        bytes memory data,uint256[2] memory signature
+        ) external view returns (bool) {
+        return BLS.verifyHelpedAggregationPublicKeysRec(aggregated_p1, aggregated_g2, data,signature);
+    }
+
 }


### PR DESCRIPTION
#10 
Thank you @ChihChengLiang  for pointing out helped aggregation, exactly what i needed to implement a multisig bls wallet compatible with an EIP-4337 entrypoint.

I noticed that @kobigurk proof of concept implementation [https://gist.github.com/kobigurk/257c1783ddf556e330f31ed57febc1d9](url), uses [7875458235035678754887153468411793526875066621955642619646139314277366414792, 8106623690154677659962327366078301943507317780154727084061147098569974335996] as a generator for G1, while py_ecc uses [1,2]. Do you happen to know if one is preferred over the other ?